### PR TITLE
Fix shouldHaveReceived parameters declaration

### DIFF
--- a/library/Mockery/MockInterface.php
+++ b/library/Mockery/MockInterface.php
@@ -99,7 +99,7 @@ interface MockInterface
      * @param null $args
      * @return mixed
      */
-    public function shouldHaveReceived($method, $args = null);
+    public function shouldHaveReceived($method = null, $args = null);
 
     /**
      * @return mixed


### PR DESCRIPTION
According to `MockInterface` the first argument of `shouldHaveReceived()` is required, whereas it can be used with no parameter.
Fix #894.